### PR TITLE
Update the versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/substack/wsnc",
   "dependencies": {
     "defined": "^1.0.0",
-    "minimist": "^1.1.1",
-    "websocket-stream": "^1.4.0"
+    "minimist": "^1.2.0",
+    "websocket-stream": "^2.1.0"
   }
 }


### PR DESCRIPTION
Installing wsnc fails on node 5.0.0 because some dependent libraries with old versions fails to install.

I updated versions of dependencies and installing works now.

Please check this pull request.